### PR TITLE
Add a cli prompt for the user in case the first file does not look like a td.dat file.

### DIFF
--- a/source/dat_to_es.cpp
+++ b/source/dat_to_es.cpp
@@ -116,6 +116,16 @@ int main(int argc, char* argv[]) {
             if (command.arguments[0] == command.arguments[1]) {
                 throw std::runtime_error("The td and aps inputs must be different files, and cannot be both none");
             }
+	    if (command.arguments[0].find("td") == std::string::npos) {
+	    	std::cout << "The file " << command.arguments[0] << " does not have 'td' in its name. Do you want to continue anyway? (Y/n)" << '\n';
+		std::string answer;
+		std::getline(std::cin, answer);
+		if (answer == "n") {		
+	            throw std::runtime_error("Aborting...");
+		} else {
+                    std::cout << "Continuing..." << '\n';
+		}
+	    }
             if (command.arguments[0] == command.arguments[2]) {
                 throw std::runtime_error("The td input and the Event Stream output must be different files");
             }

--- a/source/dat_to_es.cpp
+++ b/source/dat_to_es.cpp
@@ -116,16 +116,16 @@ int main(int argc, char* argv[]) {
             if (command.arguments[0] == command.arguments[1]) {
                 throw std::runtime_error("The td and aps inputs must be different files, and cannot be both none");
             }
-	    if (command.arguments[0].find("td") == std::string::npos) {
-	    	std::cout << "The file " << command.arguments[0] << " does not have 'td' in its name. Do you want to continue anyway? (Y/n)" << '\n';
-		std::string answer;
-		std::getline(std::cin, answer);
-		if (answer == "n") {		
-	            throw std::runtime_error("Aborting...");
-		} else {
+            if (command.arguments[0].find("td") == std::string::npos) {
+                std::cout << "The file " << command.arguments[0] << " does not have 'td' in its name. Do you want to continue anyway? (Y/n)" << '\n';
+                std::string answer;
+                std::getline(std::cin, answer);
+                if (answer == "n") {
+                    throw std::runtime_error("Aborting...");
+                } else {
                     std::cout << "Continuing..." << '\n';
-		}
-	    }
+		            }
+	          }
             if (command.arguments[0] == command.arguments[2]) {
                 throw std::runtime_error("The td input and the Event Stream output must be different files");
             }


### PR DESCRIPTION
Previously it was possible to mix up the aps and td file, which would still output a result (though blurry). This is meant to be a safety check, implemented simply by checking the file name. Could be improved by actually verifying file contents. 